### PR TITLE
update to Elm 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+elm-stuff/
+elm.js

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ page and how to communicate with JavaScript.
 
     git clone https://github.com/evancz/elm-html-and-js.git
     cd elm-html-and-js
-    elm-make Stamps.elm
+    elm-make Stamps.elm --output elm.js
     open index.html
 
 ### Overview of API Usage

--- a/Stamps.elm
+++ b/Stamps.elm
@@ -4,7 +4,6 @@ import Color exposing (..)
 import Graphics.Collage exposing (..)
 import Graphics.Element exposing (..)
 import Mouse
-import Signal exposing ((<~))
 import Window
 
 
@@ -16,8 +15,8 @@ port reset : Signal ()
 events : Signal (Maybe (Int,Int))
 events =
   Signal.merge
-    (Just <~ Signal.sampleOn Mouse.clicks Mouse.position)
-    (always Nothing <~ reset)
+    (Signal.map Just (Signal.sampleOn Mouse.clicks Mouse.position))
+    (Signal.map (always Nothing) reset)
 
 
 -- Keep a list of stamps, resetting when appropriate

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.0",
+    "summary": "example project for embedding Elm in HTML plus JS interops",
+    "repository": "https://github.com/evancz/elm-html-and-js.git",
+    "license": "BSD3",
+    "source-directories": [
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.16.0 <= v < 0.17.0"
+}


### PR DESCRIPTION
This updates the example project to be compatible with Elm 0.16.
- Replace `<~` with `Signal.map`.
- add elm-package.json to fix Elm version and core package version
- Update commands in README.md so that index.html will not be overwritten by elm-make 
